### PR TITLE
Removed numpy and matplotlib from packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     name='nwbwidgets',
-    packages=['nwbwidgets', 'numpy', 'matplotlib'],
+    packages=['nwbwidgets',],
     python_requires='>=2.7',
     setup_requires=['setuptools>=38.6.0', 'setuptools_scm'],
     url='https://github.com/NeurodataWithoutBorders/nwb-jupyter-widgets',


### PR DESCRIPTION
I'm not sure why those were in there... but it breaks the installation, because there are not additional packages in directories called `matplotlib` and `numpy`.

Seems to build and install OK now (though it's not clear where I'm supposed to get sample data... will open a separate issue for that): https://gigantum.com/tinydav/nwb-ipy-widget-testing