### PR TITLE
bisect_left for timestamps

### DIFF
--- a/nwbwidgets/utils/timeseries.py
+++ b/nwbwidgets/utils/timeseries.py
@@ -1,7 +1,7 @@
 from pynwb import TimeSeries
 
 import numpy as np
-from bisect import bisect
+from bisect import bisect_left
 
 
 def get_timeseries_tt(node: TimeSeries, istart=0, istop=None) -> np.ndarray:
@@ -125,7 +125,7 @@ def timeseries_time_to_ind(node: TimeSeries, time, ind_min=None, ind_max=None) -
             kwargs.update(lo=ind_min)
         if ind_max is not None:
             kwargs.update(hi=ind_max)
-        return bisect(node.timestamps, time, **kwargs)
+        return bisect_left(node.timestamps, time, **kwargs)
     else:
         if np.isnan(node.starting_time):
             starting_time = 0

--- a/nwbwidgets/utils/timeseries.py
+++ b/nwbwidgets/utils/timeseries.py
@@ -4,7 +4,15 @@ import numpy as np
 from bisect import bisect_left
 
 
-def get_timeseries_tt(node: TimeSeries, istart=0, istop=None) -> np.ndarray:
+def check_index(ind_start, ind_end):
+    if ind_end == ind_start:
+        if ind_end is not None:
+            ind_end = ind_start + 1
+    elif ind_start is None and ind_end == 0:
+        ind_end = 1
+    return ind_start, ind_end
+
+def get_timeseries_tt(node: TimeSeries, istart=0, istop=-1) -> np.ndarray:
     """
     For any TimeSeries, return timestamps. If the TimeSeries uses starting_time and rate, the timestamps will be
     generated.
@@ -22,6 +30,7 @@ def get_timeseries_tt(node: TimeSeries, istart=0, istop=None) -> np.ndarray:
     numpy.ndarray
 
     """
+    istart, istop = check_index(istart,istop)
     if node.timestamps is not None:
         return node.timestamps[istart:istop]
     else:
@@ -94,6 +103,7 @@ def get_timeseries_in_units(node: TimeSeries, istart=None, istop=None):
     numpy.ndarray, str
 
     """
+    istart, istop = check_index(istart, istop)
     data = node.data[istart:istop]
     if node.conversion and np.isfinite(node.conversion):
         data = data * node.conversion
@@ -147,6 +157,7 @@ def align_by_times(timeseries: TimeSeries, starts, stops):
     for istart, istop in zip(starts, stops):
         ind_start = timeseries_time_to_ind(timeseries, istart)
         ind_stop = timeseries_time_to_ind(timeseries, istop, ind_min=ind_start)
+        ind_start, ind_stop = check_index(ind_start, ind_stop)
         out.append(timeseries.data[ind_start:ind_stop])
     return np.array(out)
 


### PR DESCRIPTION
I'm facing a problem with a timeseries with timestamps like: [2.49, 14, 22 ...] , so a super low rate. Opening this in widgets: the slider for time starts at ts[0]=2.49 and the default duration window 5s, so the time_window is [2.49,7.49]. Using `bisect.bisect` to retrieve the start/end indices gives 0 for both.  THis causes the output data to be an empty list ( [here](https://github.com/NeurodataWithoutBorders/nwb-jupyter-widgets/blob/master/nwbwidgets/timeseries.py#L260). But if `bisect.bisect_left` is used (which is only different from `bisect.bisect` when the [value for index is already within the array](https://docs.python.org/3/library/bisect.html#bisect.bisect)) the problem is solved. 
I dont see any other case where this would fail. 

Below is the error without this change:
```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
~\Documents\NWB\roiextractors\venv\lib\site-packages\ipywidgets\widgets\widget.py in _handle_msg(self, msg)
    674                 if 'buffer_paths' in data:
    675                     _put_buffers(state, data['buffer_paths'], msg['buffers'])
--> 676                 self.set_state(state)
    677 
    678         # Handle a state request.

~\Documents\NWB\roiextractors\venv\lib\site-packages\ipywidgets\widgets\widget.py in set_state(self, sync_data)
    543                     from_json = self.trait_metadata(name, 'from_json',
    544                                                     self._trait_from_json)
--> 545                     self.set_trait(name, from_json(sync_data[name], self))
    546 
    547     def send(self, content, buffers=None):

~\anaconda3\lib\contextlib.py in __exit__(self, type, value, traceback)
    118         if type is None:
    119             try:
--> 120                 next(self.gen)
    121             except StopIteration:
    122                 return False

~\Documents\NWB\roiextractors\venv\lib\site-packages\traitlets\traitlets.py in hold_trait_notifications(self)
   1212                 for changes in cache.values():
   1213                     for change in changes:
-> 1214                         self.notify_change(change)
   1215 
   1216     def _notify_trait(self, name, old_value, new_value):

~\Documents\NWB\roiextractors\venv\lib\site-packages\ipywidgets\widgets\widget.py in notify_change(self, change)
    604                 # Send new state to front-end
    605                 self.send_state(key=name)
--> 606         super(Widget, self).notify_change(change)
    607 
    608     def __repr__(self):

~\Documents\NWB\roiextractors\venv\lib\site-packages\traitlets\traitlets.py in notify_change(self, change)
   1225     def notify_change(self, change):
   1226         """Notify observers of a change event"""
-> 1227         return self._notify_observers(change)
   1228 
   1229     def _notify_observers(self, event):

~\Documents\NWB\roiextractors\venv\lib\site-packages\traitlets\traitlets.py in _notify_observers(self, event)
   1262                 c = getattr(self, c.name)
   1263 
-> 1264             c(event)
   1265 
   1266     def _add_notifiers(self, handler, name, type):

c:\users\saksham\documents\nwb\nwb-jupyter-widgets\nwbwidgets\base.py in on_selected_index(change)
     92     def on_selected_index(change):
     93         if change.new is not None and isinstance(change.owner.children[change.new], widgets.HTML):
---> 94             children[change.new] = nwb2widget(list(d.values())[change.new], neurodata_vis_spec=neurodata_vis_spec,
     95                                               **pass_kwargs)
     96             change.owner.children = children

c:\users\saksham\documents\nwb\nwb-jupyter-widgets\nwbwidgets\base.py in nwb2widget(node, neurodata_vis_spec, **pass_kwargs)
    202                 return lazy_tabs(spec, node)
    203             elif callable(spec):
--> 204                 return vis2widget(spec(node, neurodata_vis_spec=neurodata_vis_spec, **pass_kwargs))
    205     out1 = widgets.Output()
    206     with out1:

c:\users\saksham\documents\nwb\nwb-jupyter-widgets\nwbwidgets\timeseries.py in show_timeseries(node, **kwargs)
    167 def show_timeseries(node, **kwargs):
    168     if len(node.data.shape) == 1:
--> 169         return SingleTracePlotlyWidget(node, **kwargs)
    170     elif len(node.data.shape) == 2:
    171         return BaseGroupedTraceWidget(node, **kwargs)

c:\users\saksham\documents\nwb\nwb-jupyter-widgets\nwbwidgets\timeseries.py in __init__(self, timeseries, foreign_time_window_controller, **kwargs)
    227                  foreign_time_window_controller: StartAndDurationController = None,
    228                  **kwargs):
--> 229         super().__init__(timeseries=timeseries,
    230                          foreign_time_window_controller=foreign_time_window_controller,
    231                          **kwargs)

c:\users\saksham\documents\nwb\nwb-jupyter-widgets\nwbwidgets\timeseries.py in __init__(self, timeseries, foreign_time_window_controller, **kwargs)
    194 
    195         self.set_controls(**kwargs)
--> 196         self.set_out_fig()
    197         self.set_children()
    198 

c:\users\saksham\documents\nwb\nwb-jupyter-widgets\nwbwidgets\timeseries.py in set_out_fig(self)
    250             xaxis_title="time (s)",
    251             yaxis_title=units,
--> 252             yaxis={"range": [min(yy), max(yy)], "autorange": False},
    253             xaxis={"range": [min(self.out_fig.data[0].x), max(self.out_fig.data[0].x)], "autorange": False}
    254         )

ValueError: min() arg is an empty sequence
```