### PR TITLE
load roi_table_region data into mem

### DIFF
--- a/nwbwidgets/timeseries.py
+++ b/nwbwidgets/timeseries.py
@@ -470,7 +470,7 @@ class BaseGroupedTraceWidget(widgets.HBox):
             if dynamic_table_region_name is not None:
                 dynamic_table_region = getattr(time_series, dynamic_table_region_name)
                 table = dynamic_table_region.table
-                referenced_rows = dynamic_table_region.data
+                referenced_rows = np.array(dynamic_table_region.data)
                 discard_rows = [x for x in range(len(table)) if x not in referenced_rows]
                 self.gas = GroupAndSortController(dynamic_table=table, start_discard_rows=discard_rows)
                 self.controls.update(gas=self.gas)


### PR DESCRIPTION
looping over all the ROIs and checking if each roi's id exists in a `roi_response_series.rois ` (**DynamicTableRegion** linked to the rois table) is slow since the roi_response_series.rois.data is on disc. 
Loading into memory as array makes the search fast. I dont think we would run into any memory issues though since the roi table region only has one column with a subset number of rois. 

I faced this issue when I tried to visualize the roi_response_series for two datasets 1) shape=(100, Time)  2) shape=(1900,Time). 
I was taking a long time (190+ sec) to render the default plot of widget for dataset no.2, while dataset no.1 was 2-3 secs. This change makes the dataset 1 plot also render quickly (2-3 sec)