### PR TITLE
fix display of unit ids in spiking unit widgets

### DIFF
--- a/nwbwidgets/misc.py
+++ b/nwbwidgets/misc.py
@@ -106,6 +106,7 @@ def show_session_raster(
         progress_bar=progress_bar,
     )
     ax.set_ylabel("unit #")
+    ax.set_yticklabels(units.id.data[:])
 
     return ax
 
@@ -286,7 +287,7 @@ class PSTHWidget(widgets.VBox):
         if unit_controller is None:
             nunits = len(units["spike_times"].data)
             self.unit_controller = widgets.Dropdown(
-                options=[x for x in range(nunits)],
+                options=[(str(units.id.data[x]), x) for x in range(nunits)],
                 value=unit_index,
                 description="unit",
                 layout=Layout(width="200px"),
@@ -836,7 +837,7 @@ class RasterGridWidget(widgets.VBox):
 
         trial_event_controller = make_trial_event_controller(self.trials)
         unit_controller = widgets.Dropdown(
-            options=range(len(units["spike_times"].data)),
+            options=[(str(units.id.data[x]), x) for x in range(len(units["spike_times"].data))],
             value=unit_index,
             description="unit",
         )

--- a/nwbwidgets/misc.py
+++ b/nwbwidgets/misc.py
@@ -285,9 +285,10 @@ class PSTHWidget(widgets.VBox):
             self.trials = trials
 
         if unit_controller is None:
-            nunits = len(units["spike_times"].data)
+            unit_ids = units.id.data[:]
+            n_units = len(unit_ids)
             self.unit_controller = widgets.Dropdown(
-                options=[(str(units.id.data[x]), x) for x in range(nunits)],
+                options=[(str(unit_ids[x]), x) for x in range(n_units)],
                 value=unit_index,
                 description="unit",
                 layout=Layout(width="200px"),
@@ -836,8 +837,11 @@ class RasterGridWidget(widgets.VBox):
         )
 
         trial_event_controller = make_trial_event_controller(self.trials)
+
+        unit_ids = units.id.data[:]
+        n_units = len(unit_ids)
         unit_controller = widgets.Dropdown(
-            options=[(str(units.id.data[x]), x) for x in range(len(units["spike_times"].data))],
+            options=[(str(unit_ids[x]), x) for x in range(n_units)],
             value=unit_index,
             description="unit",
         )


### PR DESCRIPTION
@bendichter Is there someone I should ping as a point-person for the widgets?

This PR fixes the display of unit ids in session raster widget as well as dropdowns in PSTH and RasterGrid widgets - before, they displayed unit ids as the index to the units table, not the unit id itself. Now appears as
![image](https://user-images.githubusercontent.com/51133164/118320968-eeef8480-b4ca-11eb-9246-6f6b893bf4f2.png)
