### PR TITLE
Change before / after to start / end controllers

### DIFF
--- a/nwbwidgets/misc.py
+++ b/nwbwidgets/misc.py
@@ -461,22 +461,22 @@ class PSTHWidget(widgets.VBox):
             self.gaussian_sd_ft.layout.height = None
             # expanded data so that gaussian smoother uses larger window than is viewed
             expanded_data = align_by_time_intervals(
-                self.units,
-                index,
-                self.trials,
-                start_label,
-                start_label,
-                start + sigma_in_secs * 4,
-                end + sigma_in_secs * 4,
-                order,
+                units=self.units,
+                index=index,
+                intervals=self.trials,
+                start_label=start_label,
+                stop_label=start_label,
+                start=start - sigma_in_secs * 4,
+                end=end + sigma_in_secs * 4,
+                rows_select=order,
                 progress_bar=progress_bar,
             )
             show_psth_smoothed(
-                expanded_data,
-                axs[1],
-                start + sigma_in_secs * 4,
-                end + sigma_in_secs * 4,
-                group_inds,
+                data=expanded_data,
+                ax=axs[1],
+                start=start - sigma_in_secs * 4,
+                end=end + sigma_in_secs * 4,
+                group_inds=group_inds,
                 sigma_in_secs=sigma_in_secs,
                 ntt=ntt,
             )

--- a/nwbwidgets/utils/units.py
+++ b/nwbwidgets/utils/units.py
@@ -88,8 +88,8 @@ def align_by_trials(
     index,
     start_label="start_time",
     stop_label=None,
-    before=0.0,
-    after=1.0,
+    start=-0.5,
+    end=1.0,
 ):
     """
     Args:
@@ -98,16 +98,16 @@ def align_by_trials(
             default: 'start_time'
         stop_label: str
             default: None (just align to start_time)
-        before: float
-            time after start_label in secs (positive goes back in time)
-        after: float
-            time after stop_label in secs (positive goes forward in time)
+        start: float
+            Start time for calculation before or after (negative or positive) the reference point (aligned to).
+        end: float
+            End time for calculation before or after (negative or positive) the reference point (aligned to).
     Returns:
         np.array(shape=(n_trials, n_time, ...))
     """
     trials = units.get_ancestor("NWBFile").trials
     return align_by_time_intervals(
-        units, index, trials, start_label, stop_label, before, after
+        units, index, trials, start_label, stop_label, start, end
     )
 
 
@@ -117,8 +117,8 @@ def align_by_time_intervals(
     intervals,
     start_label="start_time",
     stop_label="stop_time",
-    before=0.0,
-    after=0.0,
+    start=0.0,
+    end=0.0,
     rows_select=(),
     progress_bar=None,
 ):
@@ -131,10 +131,10 @@ def align_by_time_intervals(
             default: 'start_time'
         stop_label: str
             default: 'stop_time'
-        before: float
-            time after start_label in secs (positive goes back in time)
-        after: float
-            time after stop_label in secs (positive goes forward in time)
+        start: float
+            Start time for calculation before or after (negative or positive) the reference point (aligned to).
+        end: float
+            End time for calculation before or after (negative or positive) the reference point (aligned to).
         rows_select: array_like, optional
             sub-selects specific rows
         progress_bar: FloatProgress, optional
@@ -144,15 +144,15 @@ def align_by_time_intervals(
     """
     if stop_label is None:
         stop_label = start_label
-    starts = np.array(intervals[start_label][:])[rows_select] - before
-    stops = np.array(intervals[stop_label][:])[rows_select] + after
+    starts = np.array(intervals[start_label][:])[rows_select] + start
+    stops = np.array(intervals[stop_label][:])[rows_select] + end
     if progress_bar is not None:
         progress_bar.value = 0
         progress_bar.description = "reading spike data"
 
     out = []
     for i, x in enumerate(align_by_times(units, index, starts, stops)):
-        out.append(x - before)
+        out.append(x + start)
         if progress_bar is not None:
             progress_bar.value = i / len(units)
 


### PR DESCRIPTION
Changed time interval controllers to allow for a more flexible way of choosing intervals to be plotted and used for calculations of average rates.

- [x] Changed name before -> start  
- [x] Changed name after -> end
- [x] Changed FloatSlider to FloatText widgets
- [x] Added descriptive tooltips 

Example:
![Peek 2021-07-26 14-13](https://user-images.githubusercontent.com/24541631/126987381-b7d0a40c-27a3-4396-857d-3e85fd387b0b.gif)
