### PR TITLE
Two photon series fixes

### DIFF
--- a/nwbwidgets/image.py
+++ b/nwbwidgets/image.py
@@ -65,7 +65,6 @@ class ImageSeriesWidget(widgets.VBox):
                 img_fig = px.imshow(get_frame(path_ext_file, index), binary_string=True)
                 _add_fig_trace(img_fig, index)
 
-            n_samples = get_frame_count(path_ext_file)
             if foreign_time_window_controller is None:
                 self.time_window_controller = StartAndDurationController(tmax, tmin)
             else:

--- a/nwbwidgets/ophys.py
+++ b/nwbwidgets/ophys.py
@@ -37,26 +37,24 @@ class TwoPhotonSeriesWidget(widgets.VBox):
             else:
                 self.figure.for_each_trace(lambda trace: trace.update(img_fig.data[0]))
             self.figure.layout.title = f"Frame no: {index}"
+        if indexed_timeseries.external_file is not None:
+            path_ext_file = indexed_timeseries.external_file[0]
+            # Get Frames dimensions
+            tif = TiffFile(path_ext_file)
+            n_samples = len(tif.pages)
+            page = tif.pages[0]
+            n_y, n_x = page.shape
 
-        if indexed_timeseries.data is None:
-            if indexed_timeseries.external_file is not None:
-                path_ext_file = indexed_timeseries.external_file[0]
-                # Get Frames dimensions
-                tif = TiffFile(path_ext_file)
-                n_samples = len(tif.pages)
-                page = tif.pages[0]
-                n_y, n_x = page.shape
-
-                def update_figure(index=0):
-                    # Read first frame
-                    img_fig = px.imshow(
-                        imread(path_ext_file, key=int(index)), binary_string=True
-                    )
-                    _add_fig_trace(img_fig, index)
-
-                slider = widgets.IntSlider(
-                    value=0, min=0, max=n_samples - 1, orientation="horizontal"
+            def update_figure(index=0):
+                # Read first frame
+                img_fig = px.imshow(
+                    imread(path_ext_file, key=int(index)), binary_string=True
                 )
+                _add_fig_trace(img_fig, index)
+
+            slider = widgets.IntSlider(
+                value=0, min=0, max=n_samples - 1, orientation="horizontal"
+            )
         else:
             if len(indexed_timeseries.data.shape) == 3:
 

--- a/nwbwidgets/ophys.py
+++ b/nwbwidgets/ophys.py
@@ -3,7 +3,6 @@ from functools import lru_cache
 import ipywidgets as widgets
 import numpy as np
 import plotly.graph_objects as go
-import plotly.express as px
 from ndx_grayscalevolume import GrayscaleVolume
 from pynwb.base import NWBDataInterface
 from pynwb.ophys import (
@@ -14,14 +13,13 @@ from pynwb.ophys import (
     ImageSegmentation,
 )
 from skimage import measure
-from tifffile import imread, TiffFile
 
 from .base import df_to_hover_text
+from .controllers import ProgressBar
+from .image import ImageSeriesWidget
 from .timeseries import BaseGroupedTraceWidget
 from .utils.cmaps import linear_transfer_function
 from .utils.dynamictable import infer_categorical_columns
-from .controllers import ProgressBar
-from .image import ImageSeriesWidget
 
 color_wheel = ["red", "blue", "green", "black", "magenta", "yellow"]
 
@@ -157,13 +155,13 @@ class PlaneSegmentation2DWidget(widgets.VBox):
                     data.showlegend = False
 
     def show_plane_segmentation_2d(
-        self,
-        color_wheel: list = color_wheel,
-        color_by: str = None,
-        threshold: float = 0.01,
-        fig: go.Figure = None,
-        width: int = 600,
-        ref_image=None,
+            self,
+            color_wheel: list = color_wheel,
+            color_by: str = None,
+            threshold: float = 0.01,
+            fig: go.Figure = None,
+            width: int = 600,
+            ref_image=None,
     ):
         """
 
@@ -294,6 +292,6 @@ def show_grayscale_volume(vol: GrayscaleVolume, neurodata_vis_spec: dict):
 
 class RoiResponseSeriesWidget(BaseGroupedTraceWidget):
     def __init__(
-        self, roi_response_series: RoiResponseSeries, neurodata_vis_spec=None, **kwargs
+            self, roi_response_series: RoiResponseSeries, neurodata_vis_spec=None, **kwargs
     ):
         super().__init__(roi_response_series, "rois", **kwargs)

--- a/test/test_ophys.py
+++ b/test/test_ophys.py
@@ -73,28 +73,30 @@ class CalciumImagingTestCase(unittest.TestCase):
             "2d_plane_seg",
             self.image_series,
         )
+        self.ps2.add_column("type", "desc")
+        self.ps2.add_column("type2", "desc")
 
         w, h = 3, 3
         img_mask1 = np.zeros((w, h))
         img_mask1[0, 0] = 1.1
         img_mask1[1, 1] = 1.2
         img_mask1[2, 2] = 1.3
-        self.ps2.add_roi(image_mask=img_mask1)
+        self.ps2.add_roi(image_mask=img_mask1, type=1, type2=0)
 
         img_mask2 = np.zeros((w, h))
         img_mask2[0, 0] = 2.1
         img_mask2[1, 1] = 2.2
-        self.ps2.add_roi(image_mask=img_mask2)
+        self.ps2.add_roi(image_mask=img_mask2, type=1, type2=1)
 
         img_mask2 = np.zeros((w, h))
         img_mask2[0, 0] = 9.1
         img_mask2[1, 1] = 10.2
-        self.ps2.add_roi(image_mask=img_mask2)
+        self.ps2.add_roi(image_mask=img_mask2, type=2, type2=0)
 
         img_mask2 = np.zeros((w, h))
         img_mask2[0, 0] = 3.5
         img_mask2[1, 1] = 5.6
-        self.ps2.add_roi(image_mask=img_mask2)
+        self.ps2.add_roi(image_mask=img_mask2, type=2, type2=1)
 
         fl = Fluorescence()
         rt_region = self.ps2.create_roi_table_region(
@@ -130,12 +132,14 @@ class CalciumImagingTestCase(unittest.TestCase):
     def test_show_df_over_f(self):
         dff = show_df_over_f(self.df_over_f, default_neurodata_vis_spec)
         assert isinstance(dff, widgets.Widget)
-        dff.controls['gas'].window = [1,2]
+        dff.controls['gas'].window = [1, 2]
 
     def test_plane_segmentation_2d_widget(self):
         wid = PlaneSegmentation2DWidget(self.ps2)
         assert isinstance(wid, widgets.Widget)
         wid.button.click()
+        wid.cat_controller.value = "type"
+        wid.cat_controller.value = "type2"
 
     def test_show_plane_segmentation_3d_mask(self):
         ps3 = PlaneSegmentation(

--- a/test/test_timeseries.py
+++ b/test/test_timeseries.py
@@ -15,6 +15,7 @@ from nwbwidgets.timeseries import (
     SeparateTracesPlotlyWidget,
     get_timeseries_tt,
     show_indexed_timeseries_plotly,
+    show_timeseries_mpl,
 )
 from pynwb import TimeSeries
 from pynwb.epoch import TimeIntervals
@@ -31,6 +32,20 @@ def test_timeseries_widget():
     )
 
     BaseGroupedTraceWidget(ts)
+
+
+def test_show_timeseries_mpl():
+
+    ts = TimeSeries(
+        name="name",
+        description="no description",
+        data=np.array([[1.0, 2.0, 3.0, 4.0], [11.0, 12.0, 13.0, 14.0]]),
+        rate=100.0,
+        unit="m",
+    )
+
+    show_timeseries_mpl(ts)
+    show_timeseries_mpl(ts, time_window=(0.0, 1.0))
 
 
 class TestTracesPlotlyWidget(unittest.TestCase):


### PR DESCRIPTION
Updating the `ImageSeriesWidget` and making `TwoPhotonSeriesWidget` as a child class. 

1. Changes to `ImageSeriesWidget`:
- in case of `external_file`:
   - Formats supported: Tif > [Tif, mp4, avi.. videos] 
   - Creates an additional widget which helps the user choose which of the file from the list of `external_file` needs to be viz.  

2. Changes to `TwoPhotonSeriesWidget`: 
- Inherits from `ImageSeriesWidget`