### PR TITLE
color by columns that are 1d vectors

### DIFF
--- a/nwbwidgets/ophys.py
+++ b/nwbwidgets/ophys.py
@@ -279,7 +279,7 @@ class PlaneSegmentation2DWidget(widgets.VBox):
         plane_seg_hover_dict = {
             key: self.plane_seg[key].data
             for key in self.plane_seg.colnames
-            if key not in ["pixel_mask", "image_mask"]
+            if len(self.plane_seg[key].data.shape) == 1
         }
         plane_seg_hover_dict.update(id=self.plane_seg.id.data)
         plane_seg_hover_df = pd.DataFrame(plane_seg_hover_dict)


### PR DESCRIPTION
while plotting traces of `image_masks` from the PlaneSegmentation table, legend groups should only be made for columns that are 1d vectors. Columns for `image_mask`/`pixel_mask`/`Centroid` etc are 2d or 3d vectors, for which color by would not make sense. Additionally, for such columns there would be as many groups as no of rows. 