### PR TITLE
dandi authenticate

### DIFF
--- a/nwbwidgets/panel.py
+++ b/nwbwidgets/panel.py
@@ -1,7 +1,7 @@
 import concurrent.futures
 import warnings
 from pathlib import Path
-
+import os
 import fsspec
 import h5py
 import ipywidgets as widgets
@@ -292,6 +292,9 @@ class Panel(widgets.VBox):
 
     def get_all_dandisets_metadata(self):
         with DandiAPIClient() as client:
+            api_key = os.environ.get("DANDI_API_KEY", None)
+            if api_key:
+                client.dandi_authenticate()
             all_metadata = []
             dandisets = list(client.get_dandisets())
             total_dandisets = len(dandisets)

--- a/nwbwidgets/panel.py
+++ b/nwbwidgets/panel.py
@@ -1,7 +1,8 @@
 import concurrent.futures
+import os
 import warnings
 from pathlib import Path
-import os
+
 import fsspec
 import h5py
 import ipywidgets as widgets


### PR DESCRIPTION
- [ ] Still depends on [this](https://github.com/dandi/dandi-cli/issues/1363) to be solved before we can list embargoed dandisets
- [ ] `_stream_s3_file` method might need to include the api key as token in the header as well